### PR TITLE
Adjust installation instructions

### DIFF
--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -14,13 +14,13 @@ Installation / Usage
 
 To install use pip:
 
-    $ pip install xontrib-{{cookiecutter.project_slug}}
+    $ xip install xontrib-{{cookiecutter.project_slug}}
 
 
 Or clone the repo:
 
     $ git clone https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}.git
-    $ python setup.py install
+    $ xip install ./{{cookiecutter.project_slug}}
 
 Contributing
 ------------


### PR DESCRIPTION
1. Don't call `setup.py` directly anymore (take-away from https://us.pycon.org/2017/schedule/presentation/319/ )
2. Use `xip` so it actually ends up with xonsh.